### PR TITLE
modify tsv_to_json tutorial dataset

### DIFF
--- a/Named Entity Recognition/tsv_to_json_custom.py
+++ b/Named Entity Recognition/tsv_to_json_custom.py
@@ -1,9 +1,27 @@
+# Convert .tsv file to dataturks json format. 
 import json
 import logging
 import sys
+import csv 
+
+
+
+def process_line(line, start):
+    sentence,word,pos,tag=line
+    
+    if tag!='O':
+        d={}
+        d['text']=word
+        d['start']=start
+        d['end']=start+len(word)-1
+    else:
+        d = None
+    move =len(word)+1
+    return d,word, tag, move
+
 def tsv_to_json_format(input_path,output_path,unknown_label):
     try:
-        f=open(input_path,'r') # input file
+        f = get_csv( input_path )
         fp=open(output_path, 'w') # output file
         data_dict={}
         annotations =[]
@@ -11,28 +29,21 @@ def tsv_to_json_format(input_path,output_path,unknown_label):
         s=''
         start=0
         for line in f:
-            if line[0:len(line)-1]!='.\tO':
-                word,entity=line.split('\t')
+            if 'Sentence' not in line[0]:
+                d, word, tag, move = process_line(line, start)
+                start += move
                 s+=word+" "
-                entity=entity[:len(entity)-1]
-                if entity!=unknown_label:
-                    if len(entity) != 1:
-                        #print(len(entity),"Yes")
-                        d={}
-                        d['text']=word
-                        #print(d['text'])
-                        d['start']=start
-                        d['end']=start+len(word)-1  
-                        #print(d['start'],d['end'])
-                        try:
-                            label_dict[entity].append(d)
-                        except:
-                            label_dict[entity]=[]
-                            label_dict[entity].append(d) 
-                start+=len(word)+1
+                if d != None:
+                    try:
+                        label_dict[tag].append(d)
+                    except:
+                        label_dict[tag]=[]
+                        label_dict[tag].append(d)
+
             else:
+                ##file away object for last sentence
+
                 data_dict['content']=s
-                s=''
                 label_list=[]
                 for ents in list(label_dict.keys()):
                     for i in range(len(label_dict[ents])):
@@ -58,13 +69,38 @@ def tsv_to_json_format(input_path,output_path,unknown_label):
                 json.dump(data_dict, fp)
                 fp.write('\n')
                 data_dict={}
+
+
+                ##start processing next sentence
                 start=0
                 label_dict={}
+                s=''
+                d, word, tag, move = process_line(line, start)
+                start += move
+                s+=word+" "
+                if d != None:
+                    try:
+                        label_dict[tag].append(d)
+                    except:
+                        label_dict[tag]=[]
+                        label_dict[tag].append(d)
+
+        return data_dict
     except Exception as e:
         logging.exception("Unable to process file" + "\n" + "error = " + str(e))
         return None
 
-tsv_to_json_format("Data/ner_corpus_260.tsv",'Data/ner_corpus_260.json','abc')
+
+def get_csv( filepath ):
+    c = []      
+    with open(filepath, newline='', encoding='utf8', errors='ignore') as csvfile:
+        spamreader = csv.reader(csvfile, delimiter=',', quotechar='"')
+        next(spamreader)
+        for row in spamreader:
+            c.append(row)
+    return c
+
+tsv_to_json_format( "data/ner_dataset.csv" ,'data/ner_corpus.json','abc')
 
 
 


### PR DESCRIPTION
The tutorial (https://towardsdatascience.com/custom-named-entity-recognition-using-spacy-7140ebbb3718) was very helpful getting oriented with spaCy and NER for NLP. I found the kaggle dataset linked in the blog (https://www.kaggle.com/abhinavwalia95/entity-annotated-corpus/downloads/entity-annotated-corpus.zip/4) to be in a different format so this PR offers a rewrite of the tsv_to_json_custom.py script. 

Instructions: 
1) Download and unzip the kaggle dataset
2) Run modified tsv_to_json_custom.py
3) Run spacy_to_json_custom.py and ner.py as before without modifications